### PR TITLE
Moved searchbar api call to backend

### DIFF
--- a/client-sq/src/components/Dashboard.js
+++ b/client-sq/src/components/Dashboard.js
@@ -3,23 +3,27 @@ import useAuth from "./useAuth";
 import {Container, Form} from 'react-bootstrap';
 import SpotifyWebApi from 'spotify-web-api-node';
 import '../styles/App.css'
+import axios from 'axios';
 
 function Dashboard({code}){
     const spotifyApi = new SpotifyWebApi();
     const accessToken = useAuth(code)
-
     spotifyApi.setAccessToken(accessToken);
 
-    const onSearchChange = async(searchQuery) =>{
-        spotifyApi.searchTracks(searchQuery).then(
-        function(data) {
-            console.log('Artist albums', data.body);
-        },
-        function(err) {
-            console.error(err);
-        }
-        )
-    }
+    const searchTracks = async(searchQuery) => {
+        axios
+          .post("http://localhost:3001/searchTracks", {
+            searchString : searchQuery,
+            accessToken : accessToken,
+          })
+          .then(res => {
+            console.log(res.data.body)
+          })
+          .catch((err) => {
+            console.log(err)
+          })
+      }
+
     return (
 
     // Search Bar Component
@@ -28,7 +32,7 @@ function Dashboard({code}){
         <Form.Control
             type="search"
             placeholder="Search Songs/Artists"
-            onChange={(e)=>{onSearchChange(e.target.value)}}
+            onChange={(e)=>{searchTracks(e.target.value)}}
         />
     </Container> 
     )}

--- a/server-sq/server.js
+++ b/server-sq/server.js
@@ -4,11 +4,11 @@ const app = express();
 const cors = require('cors');
 const bodyParser = require('body-parser');
 // const SpotifyWebApi = SpotifyWebApi
-const port = 3000;
 // app.use(express.json()); // converts data into json between front and back 
 // app.use(express.static('./sq-ui/src')); // connects back to front
 app.use(cors())
 app.use(bodyParser.json())
+const spotifyApi = new SpotifyWebApi();
 
 app.post('/login', (req,res) => {
   const code = req.body.code
@@ -31,5 +31,16 @@ app.post('/login', (req,res) => {
   })
 })
 
+app.post('/searchTracks', function(req, res){
+  spotifyApi.setAccessToken(req.body.accessToken)
+  spotifyApi.searchTracks(req.body.searchString).then(
+    function(data) {
+        res.send(data);
+    },
+    function(err) {
+        console.error(err);
+    }
+    )
+}) 
 
 app.listen(3001);


### PR DESCRIPTION
This PR moves the spotify API logic from inside the dashboard component into the backend. 

When entering text into the search bar, the dashboard component makes an Axios `POST` HTTP request and sends the string to the backend, where the `searchTracks()` Spotify API call is made. The server responds to the request with an object containing up to 20 related tracks.