### PR TITLE
[feat] SQ-43 Show queue implementation.

### DIFF
--- a/client-sq/src/components/Queue.js
+++ b/client-sq/src/components/Queue.js
@@ -1,1 +1,19 @@
-// Implement Queue component to show queue
+// Component for rendering the Queue
+import React from "react"
+import axios from 'axios';
+import Track from "./Track"
+
+export default function Queue({ trackList }) {
+
+    return (
+      // Will be modified to include displaying position in queue.
+        <div className="flex-grow-1 my-2" style={{ overflowY: "auto"}}>
+            {trackList.map((track, index) => (
+              <Track 
+                track={track}
+                key={index}
+              />
+          ))}
+          </div> 
+    )
+}

--- a/server-sq/routes/queue.js
+++ b/server-sq/routes/queue.js
@@ -2,8 +2,7 @@ const express = require("express");
 const router = express.Router()
 const SpotifyWebApi = require("spotify-web-api-node");
 
-var queue = [
-];
+var queue = [];
 
 router.get('/', (req, res) => {
     res.send('Queue routing check')
@@ -13,14 +12,13 @@ router.get('/next', (req, res) => {
     res.json(queue[0])
 })
 
-router.get('/list', (req, res) => {
+router.get('/show', (req, res) => {
     res.json(queue)
 })
 
 router.post('/add', (req, res) => {
-   queue.push(req.body)
-   res.json(queue);
+    queue.push(req.body)
+    res.json(queue);
 })
-
 
 module.exports = router

--- a/server-sq/server.js
+++ b/server-sq/server.js
@@ -12,7 +12,6 @@ app.use(bodyParser.json())
 app.use('/queue', queue)
 const spotifyApi = new SpotifyWebApi();
 
-
 app.post('/login', (req,res) => {
   const code = req.body.code
 


### PR DESCRIPTION
Task Issue SQ-43: Function to show queue

This branch contains implementations to render the queue on the front end. Appearance of components on webpage are not final. Main point of this implementation:

- The queue is retrieved and rendered from the backend periodically every second using HTTP request and React hook. The **length of this interval is a placeholder** until we can verify load thresholds for the backend. 
- The queue is currently not rendered to show numbered positions in queue. However, the queue is shown in order from top to bottom i.e. song at the top is up next, bottom is most recently added.