### PR TITLE
Updated the filter function to filter out piano, classical music, and other slow/sleepy songs  

### DIFF
--- a/server-sq/routes/queue.js
+++ b/server-sq/routes/queue.js
@@ -7,7 +7,7 @@ module.exports = function(spotifyApi) {
     async function filter(trackUri) {
         let res = await spotifyApi.getAudioFeaturesForTrack(trackUri).then()
         let features = res.body;
-        console.log(features);
+        //console.log(features);
         //Parse Features - REQUIRES UPDATE
         //updated based on piano, classical music, and other slow/sleepy song track features (update if needed)
         if (features.energy <= 0.3 || 
@@ -37,11 +37,15 @@ module.exports = function(spotifyApi) {
     router.post('/add', (req, res) => {
         let filterPromise = filter(req.body.uri.replace('spotify:track:', ''))
         //console.log("SHOULD BE promise PENDING", filterPromise) // Promise { <pending> }
+        console.log(req.body);
         filterPromise.then(result=> {
-            console.log("This song is filtered out of the queue", result)
             if(result){
                 queue.push(req.body)
+                console.log("This song was added to queue")
                 }  // "boolean for filter"
+            else{
+                console.log("This song does not meet the queue requirements")
+            }
         })
         res.send("Check server for filter status");
     })

--- a/server-sq/routes/queue.js
+++ b/server-sq/routes/queue.js
@@ -3,17 +3,24 @@ const router = express.Router()
 
 module.exports = function(spotifyApi) {
     var queue = []; // Will eventually translate to playback queue.
-
+    
     async function filter(trackUri) {
-        let res = await spotifyApi.getAudioFeaturesForTrack(trackUri)
+        let res = await spotifyApi.getAudioFeaturesForTrack(trackUri).then()
         let features = res.body;
-        console.log(res.body);
+        console.log(features);
         //Parse Features - REQUIRES UPDATE
-        if (features.energy <= 0.45 || features.instrumentalness > 0.70) {
+        //updated based on piano, classical music, and other slow/sleepy song track features (update if needed)
+        if (features.energy <= 0.3 || 
+            features.loudness <= -17 ||
+            features.acousticness >= .8 ||
+            features.instrumentalness >= 0.60 ||
+            features.valence <= 0.15 ||
+            features.tempo <= 80 ) {
             return false;
         }
         return true;
     }
+    
 
     router.get('/', (req, res) => {
         res.send('Queue routing check')
@@ -28,10 +35,19 @@ module.exports = function(spotifyApi) {
     })
 
     router.post('/add', (req, res) => {
-        //console.log(req.body);
-        filter(req.body.uri.replace('spotify:track:', '')) ? queue.push(req.body): () => {res.send("Does not meet filter requirements")};
-        res.send("Added to queue");
+        let filterPromise = filter(req.body.uri.replace('spotify:track:', ''))
+        //console.log("SHOULD BE promise PENDING", filterPromise) // Promise { <pending> }
+        filterPromise.then(result=> {
+            console.log("This song is filtered out of the queue", result)
+            if(result){
+                queue.push(req.body)
+                }  // "boolean for filter"
+        })
+        res.send("Check server for filter status");
     })
 
     return router;
+
 }
+
+


### PR DESCRIPTION
The async filter function returns a promise and I added some stuff to have it be a bool to filter out songs based on track feats. The thresholds for track features were found by just looking up tempo, instrumentalness, valence, etc. for songs that would be filtered out, could update if the filter is faulty. 