### PR TITLE
Refactor API and Recently Played Song Limit

### DIFF
--- a/client-sq/src/components/Admin.js
+++ b/client-sq/src/components/Admin.js
@@ -6,7 +6,6 @@ const AUTH_URL =
 
   "https://accounts.spotify.com/authorize?client_id="+process.env.REACT_APP_CLIENT_ID+"&response_type=code&redirect_uri="+process.env.REACT_APP_BASE_URL+"/auth&scope=streaming%20user-read-email%20user-read-private%20user-library-read%20user-library-modify%20user-read-playback-state%20user-modify-playback-state"
 
-  console.log(process.env.REACT_APP_CLIENT_ID)
 export default function Admin() {
 
   return (

--- a/client-sq/src/components/App.js
+++ b/client-sq/src/components/App.js
@@ -4,15 +4,36 @@ import Dashboard from './Dashboard.js';
 import Admin from "./Admin"
 import Authorized from "./Authorized"
 import History from "./History"
-import React from "react";
+import React, { useState, useEffect, useContext } from "react";
 import NavBar from "./NavBar"
 import { Routes, Route } from "react-router-dom"
 import HowToUse from './HowToUse';
 import LandingPage from "./LandingPage";
+import { createContext } from 'react'
+import io from 'socket.io-client';
+
+export const SocketContext = createContext(io(process.env.REACT_APP_API_URL));
 
 function App() {
+
+  const apiSocket = useContext(SocketContext);
+
+  useEffect(() => {
+    
+    // Event Handlers
+    apiSocket.on('id', (res) => {
+      console.log('ID: ', res);
+    });
+
+    return () => {
+      apiSocket.off('id');
+      apiSocket.disconnect();
+    };
+  }, [])
+
   return (
     <div style={{ display: 'inline-flex', width: "100%", overflow: "hidden", backgroundColor: "#f6f8fe", height: "100vh" }}>
+    <SocketContext.Provider value={apiSocket}>
     {(localStorage.getItem('visited') === null) && <LandingPage/>}
       <NavBar />
       <Routes>
@@ -28,6 +49,7 @@ function App() {
         <Route path="/howtouse" element={<HowToUse />}>
         </Route>
       </Routes>
+    </SocketContext.Provider>
     </div>
   )
 }

--- a/client-sq/src/components/Authorized.js
+++ b/client-sq/src/components/Authorized.js
@@ -9,7 +9,7 @@ export default function Authorized() {
 
   useEffect(() => {
     axios
-      .post(process.env.REACT_APP_API_URL + "/adminLogin", {
+      .post(process.env.REACT_APP_API_URL + "/host/login", {
         code,
       })
       .then(res => {
@@ -23,12 +23,12 @@ export default function Authorized() {
 
   return (
     <Container
-      className="d-flex justify-content-center align-items-center"
-      style={{ minHeight: "100vh" }}
+    className="d-flex justify-content-center align-items-center"
+    style={{ minHeight: "100vh" }}
     >
-      <a className="btn btn-success btn-lg" href={process.env.REACT_APP_BASE_URL}>
-        Authorized. Back to Dashboard
-      </a>
+    <a className="btn btn-success btn-lg" href={process.env.REACT_APP_BASE_URL}>
+    Authorized. Back to Dashboard
+    </a>
     </Container>
   )
 }

--- a/client-sq/src/components/Dashboard.js
+++ b/client-sq/src/components/Dashboard.js
@@ -10,8 +10,12 @@ import DisplayResults from "./DisplayResults";
 import NowPlaying from "./NowPlaying";
 import SearchRoundedIcon from '@mui/icons-material/SearchRounded';
 import SearchRounded from "@mui/icons-material/SearchRounded";
+import io from 'socket.io-client'
+import { SocketContext } from './App'
 
 function Dashboard(){
+    const socket = useContext(SocketContext);
+
     const [text,setText] = useState("Loading")
     const [searchResults, setSearchResults] = useState([])
     //const [goodSongsArr, setPassArr] = useState([])
@@ -54,11 +58,7 @@ function Dashboard(){
     if (event.key === 'Enter') {
       // Perform change here
       setSearch(dynInput)
-      
-     
     }
-  
-   
   }
   
     // Hook handling retrieving the data of the queue from the backend.
@@ -70,17 +70,14 @@ function Dashboard(){
         if (!ignore) setQueueData(result.data);
       }
       fetchQueue();
-      const interval = setInterval(() => {
-        fetchQueue();
-      }, 1000);
 
-      return () => {ignore = true; clearInterval(interval);}
+      socket.on('queueAdd', (data) => {
+        setQueueData((prevData) => [...prevData, data]);
+      })
+
+      return () => {ignore = true; socket.off('addQueue');}
     }, [])
 
-  
- 
-   
-    
     useEffect(() => {
 
       function loadingDots () {
@@ -109,7 +106,7 @@ function Dashboard(){
       const searchTracks = async(searchQuery) => {
         setLoading(true)
         return axios
-          .post(process.env.REACT_APP_API_URL + "/searchTracks", {
+          .post(process.env.REACT_APP_API_URL + "/search/tracks", {
             searchString : searchQuery,
             params: {limit: 50}
           })
@@ -409,4 +406,3 @@ function Dashboard(){
     )}
 
 export default Dashboard;
-

--- a/client-sq/src/components/Dashboard.js
+++ b/client-sq/src/components/Dashboard.js
@@ -75,6 +75,10 @@ function Dashboard(){
         setQueueData((prevData) => [...prevData, data]);
       })
 
+      socket.on('queuePop', (data) => {
+        setQueueData((prevData) => prevData.shift())
+      })
+
       return () => {ignore = true; socket.off('addQueue');}
     }, [])
 

--- a/client-sq/src/components/Dashboard.js
+++ b/client-sq/src/components/Dashboard.js
@@ -76,10 +76,10 @@ function Dashboard(){
       })
 
       socket.on('queuePop', (data) => {
-        setQueueData((prevData) => prevData.shift())
+        setQueueData((prevData) => [...prevData.slice(1)]);
       })
 
-      return () => {ignore = true; socket.off('addQueue');}
+      return () => {ignore = true; socket.off('queueAdd'); socket.off('queuePop')}
     }, [])
 
     useEffect(() => {

--- a/client-sq/src/components/Dashboard.js
+++ b/client-sq/src/components/Dashboard.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useContext, useRef } from "react";
 import '../styles/App.css'
 import axios from 'axios';
 import Queue from "./Queue"
@@ -44,7 +44,7 @@ function Dashboard(){
       let ignore = false;
       
       async function fetchToken() {
-        const result = await axios(process.env.REACT_APP_API_URL + '/token')
+        const result = await axios(process.env.REACT_APP_API_URL + '/host/token')
         if(!ignore) setAccessToken(result.data)
       }
 

--- a/client-sq/src/components/History.js
+++ b/client-sq/src/components/History.js
@@ -39,6 +39,7 @@ function History() {
     socket.on('updateHistory', (data) => {
       setHistoryData((prevData) => ([data, ...prevData]))
     })
+
     return () => { 
       ignore = true;
       socket.off('updateHistory');

--- a/client-sq/src/components/History.js
+++ b/client-sq/src/components/History.js
@@ -1,12 +1,15 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import '../styles/App.css'
 import axios from 'axios';
 import Track from "./Track"
 import { Container, IconButton } from '@mui/material';
 import {  TableContainer, Table, TableBody, TableHead, tableCellClasses } from '@mui/material';
 import SearchRoundedIcon from '@mui/icons-material/SearchRounded';
+import { SocketContext } from './App';
 
 function History() {
+
+  const socket = useContext(SocketContext);
 
   const [historyData, setHistoryData] = useState([])
   const [searchedHistory, setSearchedHistory] = useState(historyData)
@@ -17,32 +20,30 @@ function History() {
 
   function handleFocus() {
     setClickedSB("#496fff");
-
   }
 
   function handleBlur() {
     setClickedSB("#a3a8bf");
-
   }
-  // Hook handling retrieving the data of the queue from the backend.
-    useEffect(() => {
-      let ignore = false;
 
-      async function fetchHistory() {
+  // Initialization
+  useEffect(() => {
 
-        const result = await axios(process.env.REACT_APP_API_URL + '/playback/history');
-        if (!ignore) setHistoryData(result.data.reverse().slice(1));
+    let ignore = false;
+    async function fetchHistory() {
+      const result = await axios(process.env.REACT_APP_API_URL + '/playback/history');
+      if (!ignore) setHistoryData(result.data.reverse());
+    }
+    fetchHistory();
 
-      }
-
-      fetchHistory();
-
-      const interval = setInterval(() => {
-        fetchHistory();
-      }, 1000);
-
-      return () => { ignore = true; clearInterval(interval); }
-    }, [])
+    socket.on('updateHistory', (data) => {
+      setHistoryData((prevData) => ([data, ...prevData]))
+    })
+    return () => { 
+      ignore = true;
+      socket.off('updateHistory');
+    }
+  }, [])
 
   const searchHistory = (term) => {
     setSearchedHistory(historyData.filter((track) => (track.title.toLowerCase().includes(term.toLowerCase()) || track.artist.toLowerCase().includes(term.toLowerCase()))))
@@ -155,7 +156,7 @@ function History() {
       <TableBody>
 
 
-      {((searchedHistory.length > 0 ) ? searchedHistory : historyData).map((track, index) => (
+      {((searchedHistory.length > 0 ) ? searchedHistory.slice(1) : historyData.slice(1)).map((track, index) => (
 
         <Track 
         track={track}
@@ -180,6 +181,6 @@ function History() {
     </div>
     </div>
   )
-}
+};
 
 export default History;

--- a/client-sq/src/components/NowPlaying.js
+++ b/client-sq/src/components/NowPlaying.js
@@ -1,57 +1,45 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import axios from 'axios';
 import ProgressBar from "./ProgressBar";
+import { SocketContext } from "./App";
 
 function NowPlaying() {
 
-    const [playbackState, setPlaybackState] = useState({
-        albumImage: [{ url: "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/A_black_image.jpg/640px-A_black_image.jpg" }],
-        artist: "Loading",
-        duration: 0,
-        progress: 0,
-        title: "Loading"
+  const io = useContext(SocketContext);
+
+  const [playbackState, setPlaybackState] = useState({
+    albumImage: [{ url: "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/A_black_image.jpg/640px-A_black_image.jpg" }],
+    artist: "Loading",
+    duration: 0,
+    progress: 0,
+    title: "Loading"
+  });
+
+  // Initialization
+  useEffect(() => {
+
+    // Socket Handlers
+    io.on('playback', (data) => {
+      setPlaybackState(data);
+    })
+
+    return () => {
+     io.off('playback');
     }
-    )
+  }, [])
 
-    useEffect(() => {
-
-        let ignore = false;
-        async function getPlayState() {
-            const result = await axios(process.env.REACT_APP_API_URL + '/playback/playState')
-            if (!ignore) setPlaybackState(result.data)
-        }
-        getPlayState()
-
-    }, [playbackState])
-
-    // const [timer, setTimer] = useState(playbackState.progress / 1000);
-    // const id = useRef(null);
-    // const clear = () => { window.clearInterval(id.current); };
-
-    // useEffect(() => {
-    //     id.current = window.setInterval(() => {
-    //         setTimer((time) => time + 1);
-    //     }, 1000);
-    //     return () => clear();
-    // }, []);
-
-    // useEffect(() => {
-    //     if (timer >= 101) {
-    //         setTimer(0);
-    //     }
-    // }, [timer]);
-
-    const millisecondsToMinute = (millisec) => {
-        var minutes = Math.floor((millisec / 1000) / 60)
-        var seconds = (millisec / 1000) % 60
-        if (Math.floor(seconds) >= 0 && Math.floor(seconds) < 10) {
-            seconds = "0" + Math.floor(seconds)
-        }
-        else {
-            seconds = Math.floor(seconds)
-        }
-        return minutes + ":" + seconds
+  // Helper Functions
+  const millisecondsToMinute = (millisec) => {
+    var minutes = Math.floor((millisec / 1000) / 60)
+    var seconds = (millisec / 1000) % 60
+    if (Math.floor(seconds) >= 0 && Math.floor(seconds) < 10) {
+      seconds = "0" + Math.floor(seconds)
     }
+    else {
+      seconds = Math.floor(seconds)
+    }
+    return minutes + ":" + seconds
+  }
 
     return (
         <div style={{ display: "inline-flex", width: "100%"}}>
@@ -61,15 +49,15 @@ function NowPlaying() {
                     style={{ height: window.innerWidth * 0.104, width: window.innerWidth * 0.104, marginTop: window.innerHeight * 0.008 }} />
             </div>
 
-            <div style={{ alignSelf: "flex-end", marginLeft: window.innerWidth * .016, width: "100%", marginBottom: -window.innerHeight * 0.006 }}>
+    <div style={{ alignSelf: "flex-end", marginLeft: window.innerWidth * .016, width: "100%", marginBottom: -window.innerHeight * 0.006 }}>
 
-                <div style={{ color: "#3d435a", fontWeight: "1000", fontSize: window.innerWidth * 0.01657, marginBottom: -window.innerHeight * 0.005 }}>{playbackState.title}</div>
-                <div style={{ color: "#3d435a", fontWeight: 700, fontSize: window.innerWidth * 0.0102, marginBottom: window.innerHeight * 0.019 }}>{playbackState.artist}</div>
-                <ProgressBar style={{marginLeft: ".01vw"}}number={(playbackState.progress / playbackState.duration) * 100} />
-                <div style={{ color: "#3d435a", fontWeight: "1000", fontSize: window.innerWidth * 0.0075, marginTop: window.innerHeight * 0.005 }}>{millisecondsToMinute(playbackState.progress)}<span style={{ float: "right" }} >{millisecondsToMinute(playbackState.duration)}</span></div>
+    <div style={{ color: "#3d435a", fontWeight: "1000", fontSize: window.innerWidth * 0.01657, marginBottom: -window.innerHeight * 0.005 }}>{playbackState.title}</div>
+    <div style={{ color: "#3d435a", fontWeight: 700, fontSize: window.innerWidth * 0.0102, marginBottom: window.innerHeight * 0.019 }}>{playbackState.artist}</div>
+    <ProgressBar style={{marginLeft: ".01vw"}}number={(playbackState.progress / playbackState.duration) * 100} />
+    <div style={{ color: "#3d435a", fontWeight: "1000", fontSize: window.innerWidth * 0.0075, marginTop: window.innerHeight * 0.005 }}>{millisecondsToMinute(playbackState.progress)}<span style={{ float: "right" }} >{millisecondsToMinute(playbackState.duration)}</span></div>
 
-            </div>
-        </div>
-    )
+    </div>
+    </div>
+  )
 }
 export default NowPlaying;

--- a/client-sq/src/index.js
+++ b/client-sq/src/index.js
@@ -6,6 +6,6 @@ import { BrowserRouter } from "react-router-dom"
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <BrowserRouter>
-    <App />
+  <App />
   </BrowserRouter>
 );

--- a/server-sq/models/SessionManager.js
+++ b/server-sq/models/SessionManager.js
@@ -1,0 +1,2 @@
+class SessionManager {
+}

--- a/server-sq/models/SessionManager.js
+++ b/server-sq/models/SessionManager.js
@@ -1,2 +1,116 @@
+const SpotifyWebApi = require("spotify-web-api-node");
+
 class SessionManager {
+  constructor(){
+    this.spotifyApi = new SpotifyWebApi({clientId: process.env.CLIENT_ID, clientSecret: process.env.CLIENT_SECRET, redirectUri: process.env.SITE_URL + '/auth'});
+    this._queue = [];
+    this._history = [];
+    this._status = {
+      host : false,
+      active : false,
+      accessToken : '',
+    };
+    this._playback = {};
+    this._buffer = [];
+  }
+
+  // Getters & Setters
+  get queue(){
+    return this._queue;
+  }
+
+  get history(){
+    return this._history;
+  }
+
+  get status(){
+    return this._status;
+  }
+
+  set accessToken(token){
+    this._status.accessToken = token;
+  }
+
+  set host(newStatus) {
+    this._status.host = newStatus;
+  }
+
+  set active(newStatus) {
+    this._status.active = newStatus;
+  }
+
+  get playback(){
+    return this._playback;
+  }
+
+  set playback(state){
+    this._playback = state;
+  }
+
+  get buffer(){
+    return this._buffer;
+  }
+
+  // Methods
+  addToQueue(item) {
+    this._queue.push(item);
+    this._buffer.push(item.uri);
+    return true;
+  }
+
+  popQueue(){
+    return this._queue.shift();
+  }
+
+  removeQueueItem(uri){
+    const index = this._queue.map(item => item.uri).indexOf(uri);
+    if (index > -1){
+      this._queue.splice(index, 1);
+    }
+  }
+
+  addToHistory(item){
+    this._history.push(item);
+  }
+
+  updateHistory(){
+    this._history.push(this._queue.shift());
+  }
+
+  // Spotify
+  authenticate(code){
+    return this.spotifyApi.authorizationCodeGrant(code).then((data) => {
+      this._status.accessToken = data.body['access_token']
+      // Set the access token on the API object to use it in later calls
+      this.spotifyApi.setAccessToken(data.body['access_token']);
+      this.spotifyApi.setRefreshToken(data.body['refresh_token']);
+      this.status.host = true; //Flag verifying token set (Concept in case we need to add more adminstrative features from client)
+      console.log('Host set')
+      return(200);
+    }, (err) => {
+      this._status.host = false;
+      console.log('Host login error: ', err);
+      return(400); 
+    }).catch(() => {
+      return(400);
+    })
+  }
+
+  refreshToken(){
+    this.spotifyApi.refreshAccessToken().then((data) => {
+      console.log('Access token refreshed');
+      this._status.accessToken = data.body['access_token'];
+      this.spotifyApi.setAccessToken(data.body['access_token']);
+    }, (err) => {
+      console.log('Failed to refresh access token: ', err);
+      this._status.host = false;
+    })
+  }
+
+  pushToSpotify(uri){
+    return this.spotifyApi.addToQueue(uri);
+  }
+
 }
+
+module.exports = SessionManager;

--- a/server-sq/models/SessionManager.js
+++ b/server-sq/models/SessionManager.js
@@ -61,6 +61,19 @@ class SessionManager {
 
   // Methods
   addToQueue(item) {
+    // Check if song is already in queue
+    for (let i = 0; i < this._queue.length; i++){
+      if(item.uri === this._queue[i].uri){
+        return false;
+      }
+    }
+    // Check if song is within the last 10 songs in history
+    for (let i = 0; i < ((this._history.length) > (10-this._queue.length) ? (10-this._queue.length): this._history.length); i++){
+      const index = this._history.length-i-1;
+      if(item.uri === this._history[index].uri){
+        return false;
+      }
+    }
     this._queue.push(item);
     this._buffer.push(item.uri);
     return true;

--- a/server-sq/models/SessionManager.js
+++ b/server-sq/models/SessionManager.js
@@ -51,6 +51,10 @@ class SessionManager {
     return this._buffer;
   }
 
+  get spotify(){
+    return this.spotifyApi;
+  }
+
   // Methods
   addToQueue(item) {
     this._queue.push(item);

--- a/server-sq/models/SessionManager.js
+++ b/server-sq/models/SessionManager.js
@@ -27,6 +27,10 @@ class SessionManager {
     return this._status;
   }
 
+  get accessToken(){
+    return this._status.accessToken;
+  }
+
   set accessToken(token){
     this._status.accessToken = token;
   }

--- a/server-sq/package-lock.json
+++ b/server-sq/package-lock.json
@@ -14,11 +14,35 @@
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "parser": "^0.1.4",
+        "socket.io": "^4.5.4",
         "spotify-web-api-node": "^5.0.2"
       },
       "devDependencies": {
         "nodemon": "^2.0.20"
       }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.13",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
+      "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.11.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -66,6 +90,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -335,6 +367,63 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/engine.io": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.1.tgz",
+      "integrity": "sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==",
+      "dependencies": {
+        "@types/cookie": "^0.4.1",
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.4.1",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.0.3",
+        "ws": "~8.2.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.5.tgz",
+      "integrity": "sha512-mjEyaa4zhuuRhaSLOdjEb57X0XPP9JEsnXI4E+ivhwT0GgzUogARx4MqoY1jQyB+4Bkz3BUOmzL7t9RMKmlG3g==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/error": {
       "version": "7.2.1",
@@ -1061,6 +1150,81 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/socket.io": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.4.tgz",
+      "integrity": "sha512-m3GC94iK9MfIEeIBfbhJs5BqFibMtkRk8ZpKwG2QwxV0m/eEhPIV4ara6XCF1LWNAus7z58RodiZlAH71U3EhQ==",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "debug": "~4.3.2",
+        "engine.io": "~6.2.1",
+        "socket.io-adapter": "~2.4.0",
+        "socket.io-parser": "~4.2.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
+      "integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg=="
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.1.tgz",
+      "integrity": "sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
     "node_modules/spotify-web-api-node": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/spotify-web-api-node/-/spotify-web-api-node-5.0.2.tgz",
@@ -1246,6 +1410,26 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/ws": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -1253,6 +1437,29 @@
     }
   },
   "dependencies": {
+    "@socket.io/component-emitter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
+    },
+    "@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+    },
+    "@types/cors": {
+      "version": "2.8.13",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
+      "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "18.11.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -1293,6 +1500,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -1503,6 +1715,48 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
+    },
+    "engine.io": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.1.tgz",
+      "integrity": "sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==",
+      "requires": {
+        "@types/cookie": "^0.4.1",
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.4.1",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.0.3",
+        "ws": "~8.2.3"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+          "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.5.tgz",
+      "integrity": "sha512-mjEyaa4zhuuRhaSLOdjEb57X0XPP9JEsnXI4E+ivhwT0GgzUogARx4MqoY1jQyB+4Bkz3BUOmzL7t9RMKmlG3g=="
     },
     "error": {
       "version": "7.2.1",
@@ -2038,6 +2292,63 @@
         }
       }
     },
+    "socket.io": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.4.tgz",
+      "integrity": "sha512-m3GC94iK9MfIEeIBfbhJs5BqFibMtkRk8ZpKwG2QwxV0m/eEhPIV4ara6XCF1LWNAus7z58RodiZlAH71U3EhQ==",
+      "requires": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "debug": "~4.3.2",
+        "engine.io": "~6.2.1",
+        "socket.io-adapter": "~2.4.0",
+        "socket.io-parser": "~4.2.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "socket.io-adapter": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
+      "integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg=="
+    },
+    "socket.io-parser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.1.tgz",
+      "integrity": "sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==",
+      "requires": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "spotify-web-api-node": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/spotify-web-api-node/-/spotify-web-api-node-5.0.2.tgz",
@@ -2176,6 +2487,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+    },
+    "ws": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+      "requires": {}
     },
     "yallist": {
       "version": "4.0.0",

--- a/server-sq/package.json
+++ b/server-sq/package.json
@@ -16,6 +16,7 @@
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "parser": "^0.1.4",
+    "socket.io": "^4.5.4",
     "spotify-web-api-node": "^5.0.2"
   },
   "devDependencies": {

--- a/server-sq/routes/host.js
+++ b/server-sq/routes/host.js
@@ -1,0 +1,48 @@
+const express = require("express");
+const router = express.Router();
+
+module.exports = function(spotifyApi, hostStatus) {
+
+  router.post('/login', (req,res) => {
+    const code = req.body.code
+    spotifyApi.authorizationCodeGrant(code).then(
+      function(data) {
+        hostStatus.accessToken = data.body['access_token']
+        // Set the access token on the API object to use it in later calls
+        spotifyApi.setAccessToken(data.body['access_token']);
+        spotifyApi.setRefreshToken(data.body['refresh_token']);
+        hostStatus.adminSet = true; //Flag verifying token set (Concept in case we need to add more adminstrative features from client)
+        console.log('Host set')
+      },
+      function(err) {
+        hostStatus.adminSet = false;
+        console.log('Error logging in host: ', err);
+      })
+      .catch(() => {
+        res.sendStatus(400);
+      })
+    res.send('Done')
+  })
+
+  router.get('/status', (req, res) => {
+    res.json(hostStatus);
+  })
+
+  router.get('/token', (req, res) => {
+    res.send(hostStatus.accessToken)
+  })
+
+  //refresh token every 30 minutes
+  setInterval(() => {
+    spotifyApi.refreshAccessToken().then((data) => {
+      console.log('Access token refreshed')
+      hostStatus.accessToken = data.body['access_token']
+      spotifyApi.setAccessToken(data.body['access_token']);
+    }, (err) => {
+      console.log('Could not refresh access token', err);
+      hostStatus.adminSet = false;
+    }
+    )}, 1800000);
+
+  return router;
+}

--- a/server-sq/routes/host.js
+++ b/server-sq/routes/host.js
@@ -1,48 +1,28 @@
 const express = require("express");
 const router = express.Router();
 
-module.exports = function(spotifyApi, hostStatus) {
+module.exports = function(session) {
 
   router.post('/login', (req,res) => {
     const code = req.body.code
-    spotifyApi.authorizationCodeGrant(code).then(
-      function(data) {
-        hostStatus.accessToken = data.body['access_token']
-        // Set the access token on the API object to use it in later calls
-        spotifyApi.setAccessToken(data.body['access_token']);
-        spotifyApi.setRefreshToken(data.body['refresh_token']);
-        hostStatus.adminSet = true; //Flag verifying token set (Concept in case we need to add more adminstrative features from client)
-        console.log('Host set')
-      },
-      function(err) {
-        hostStatus.adminSet = false;
-        console.log('Error logging in host: ', err);
-      })
-      .catch(() => {
-        res.sendStatus(400);
-      })
-    res.send('Done')
+    const authenticationStatus = session.authenticate(code);
+    authenticationStatus.then((data) => {
+      res.sendStatus(data);
+    })
   })
 
   router.get('/status', (req, res) => {
-    res.json(hostStatus);
+    res.json(session.status);
   })
 
   router.get('/token', (req, res) => {
-    res.send(hostStatus.accessToken)
+    res.send(session.accessToken)
   })
 
   //refresh token every 30 minutes
   setInterval(() => {
-    spotifyApi.refreshAccessToken().then((data) => {
-      console.log('Access token refreshed')
-      hostStatus.accessToken = data.body['access_token']
-      spotifyApi.setAccessToken(data.body['access_token']);
-    }, (err) => {
-      console.log('Could not refresh access token', err);
-      hostStatus.adminSet = false;
-    }
-    )}, 1800000);
+    session.refreshToken();
+  }, 1800000);
 
   return router;
 }

--- a/server-sq/routes/playback.js
+++ b/server-sq/routes/playback.js
@@ -29,7 +29,7 @@ module.exports = function(socket, session) {
   setInterval(() => {
     if (!session.status.host) { return; }
     session.spotify.getMyCurrentPlaybackState().then((data) => {
-      console.log('Retrieved playback state')
+      //console.log('Retrieved playback state')
       //console.log(data.body) //Debugging Purposes
       if (Object.keys(data.body).length != 0){
         if (Object.keys(session.playback).length != 0 && data.body?.item?.uri != session.playback.item.uri) {
@@ -53,6 +53,7 @@ module.exports = function(socket, session) {
           session.addToHistory(newHistoryItem)
           console.log("Added to history")
           socket.emit('updateHistory', newHistoryItem);
+          socket.emit('queuePop', 0);
         }
         else { //Debugging Purposes
           //console.log("Not added to history. Empty playback state.")

--- a/server-sq/routes/playback.js
+++ b/server-sq/routes/playback.js
@@ -29,8 +29,6 @@ module.exports = function(socket, session) {
   setInterval(() => {
     if (!session.status.host) { return; }
     session.spotify.getMyCurrentPlaybackState().then((data) => {
-      //console.log('Retrieved playback state')
-      //console.log(data.body) //Debugging Purposes
       if (Object.keys(data.body).length != 0){
         if (Object.keys(session.playback).length != 0 && data.body?.item?.uri != session.playback.item.uri) {
           const smallestAlbumImage = data.body.item.album.images.reduce(
@@ -56,7 +54,6 @@ module.exports = function(socket, session) {
           socket.emit('queuePop', 0);
         }
         else { //Debugging Purposes
-          //console.log("Not added to history. Empty playback state.")
         }
 
         session.playback = data.body; 

--- a/server-sq/routes/playback.js
+++ b/server-sq/routes/playback.js
@@ -1,21 +1,20 @@
 const express = require("express");
 const router = express.Router()
 
-module.exports = function(socket, spotifyApi, adminStatus) {
-  const history = []; 
+module.exports = function(socket, session) {
 
   router.get('/', (req, res) => {
     res.send('playback routing check')
   })
 
   router.get('/history', (req, res) => {
-    res.json(history)
+    res.json(session.history)
   })
 
   router.get('/playState', (req, res) => {
-    if (!adminStatus.adminSet || !adminStatus.playbackState.device.is_active) res.send('Host not active');
+    if (!session.status.host || !session.playback.device.is_active) res.send('Host not active');
     else {
-      const playState = adminStatus.playbackState
+      const playState = session.playback;
       res.json({
         title: playState.item.name,
         artist: playState.item.artists[0].name,
@@ -26,14 +25,14 @@ module.exports = function(socket, spotifyApi, adminStatus) {
     }
   })
 
-  // Retrieve playback state every 3 seconds and update history
+  // Retrieve playback state every 1 seconds and update history
   setInterval(() => {
-    if (!adminStatus.adminSet) { return; }
-    spotifyApi.getMyCurrentPlaybackState().then((data) => {
-      //console.log('Retrieved playback state')
+    if (!session.status.host) { return; }
+    session.spotify.getMyCurrentPlaybackState().then((data) => {
+      console.log('Retrieved playback state')
       //console.log(data.body) //Debugging Purposes
       if (Object.keys(data.body).length != 0){
-        if (Object.keys(adminStatus.playbackState).length != 0 && data.body?.item?.uri != adminStatus.playbackState.item.uri) {
+        if (Object.keys(session.playback).length != 0 && data.body?.item?.uri != session.playback.item.uri) {
           const smallestAlbumImage = data.body.item.album.images.reduce(
             (smallest, image) => {
               if (image.height < smallest.height) return image
@@ -51,7 +50,7 @@ module.exports = function(socket, spotifyApi, adminStatus) {
             explicit: data.body.item.explicit, 
             filter: true,
           }
-          history.push(newHistoryItem)
+          session.addToHistory(newHistoryItem)
           console.log("Added to history")
           socket.emit('updateHistory', newHistoryItem);
         }
@@ -59,9 +58,9 @@ module.exports = function(socket, spotifyApi, adminStatus) {
           //console.log("Not added to history. Empty playback state.")
         }
 
-        adminStatus.playbackState = data.body
-        adminStatus.activePlaying = adminStatus.playbackState.device.is_active
-        const playState = adminStatus.playbackState
+        session.playback = data.body; 
+        session.active = session.playback.device.is_active 
+        const playState = session.playback;
         const playClient = {
           title: playState.item.name,
           artist: playState.item.artists[0].name,

--- a/server-sq/routes/queue.js
+++ b/server-sq/routes/queue.js
@@ -17,11 +17,16 @@ module.exports = function(socket, session) {
 
   router.post('/add', (req, res) => {
     let added = false 
-    //if (session.status.active) {
+    if (session.status.active) {
       added = session.addToQueue(req.body);
+    }
+    if (added) {
       socket.emit('queueAdd', req.body);
-    //}
-    added ? res.send("Added to queue") : res.send("Failed to add song")
+      res.send("Added to queue");
+    }
+    else {
+      res.send("Failed to add song to queue");
+    }
   })
 
   // Add song to Spotify account queue periodically (Purpose: Reduces number of API requests)

--- a/server-sq/routes/queue.js
+++ b/server-sq/routes/queue.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const router = express.Router()
 
-module.exports = function(spotifyApi, adminStatus) {
+module.exports = function(socket, spotifyApi, adminStatus) {
   const queue = []; 
   const buffer = [];
 
@@ -23,6 +23,7 @@ module.exports = function(spotifyApi, adminStatus) {
       queue.push(req.body)
       buffer.push(req.body)
       added = true
+      socket.emit('queueAdd', req.body);
     }
     added ? res.send("Added to queue") : res.send("Failed to add song")
   })

--- a/server-sq/routes/queue.js
+++ b/server-sq/routes/queue.js
@@ -1,55 +1,51 @@
 const express = require("express");
 const router = express.Router()
 
-module.exports = function(socket, spotifyApi, adminStatus) {
-  const queue = []; 
-  const buffer = [];
+module.exports = function(socket, session) {
 
   router.get('/', (req, res) => {
     res.send('queue routing check')
   })
 
   router.get('/next', (req, res) => {
-    res.json(queue[0])
+    res.json(session.queue[0])
   })
 
   router.get('/show', (req, res) => {
-    res.json(queue)
+    res.json(session.queue)
   })
 
   router.post('/add', (req, res) => {
     let added = false 
-    if (adminStatus.activePlaying) {
-      queue.push(req.body)
-      buffer.push(req.body)
-      added = true
+    //if (session.status.active) {
+      added = session.addToQueue(req.body);
       socket.emit('queueAdd', req.body);
-    }
+    //}
     added ? res.send("Added to queue") : res.send("Failed to add song")
   })
 
   // Add song to Spotify account queue periodically (Purpose: Reduces number of API requests)
   setInterval(() => {
-    if (buffer.length < 1 || !adminStatus.activePlaying) {
+    if (session.buffer.length < 1) {
       return;
     }
-    const next = buffer.shift();
+    const next = session.buffer.shift();
     console.log('Next: ' + next);
-    spotifyApi.addToQueue(next.uri).then(() => {
+    session.spotify.addToQueue(next).then(() => {
       console.log('Added song to Spotify')
     }, (err) => {
       console.log(err)
     })
   }, 5000);
 
-  // Update queue 
+  // Popping Queue 
   setInterval(() => {
-    if (queue.length < 1 || !adminStatus.activePlaying) {
+    if (session.queue.length < 1) {
       // Empty queue
       return;
     }
-    if (Object.keys(adminStatus.playbackState).length != 0 && queue[0].uri == adminStatus.playbackState.item.uri){
-      const popped = queue.shift();
+    if (Object.keys(session.playback).length != 0 && session.queue[0].uri == session.playback.item.uri){
+      const popped = session.popQueue();
       console.log('Removed: ' + popped + 'from top of queue');
     }
 

--- a/server-sq/routes/search.js
+++ b/server-sq/routes/search.js
@@ -1,0 +1,36 @@
+const express = require("express");
+const router = express.Router()
+
+module.exports = function(spotifyApi, adminStatus) {
+
+  router.post('/tracks', function(req, res){
+    console.log('Received search');
+    const results = {
+      tracks : {},
+      features : {},
+    }
+    res.setHeader('Content-Type', 'application/json');
+    console.log('Search Query', req.body.searchString);
+    spotifyApi.searchTracks(req.body.searchString,req.body.params).then(
+      function(data) {
+        results.tracks = data.body;
+        return data.body;
+      }).then(
+        function(searchResults){
+          const idArr = [];
+          //get id array from search
+          for(let i = 0; i < searchResults.tracks.items.length; i++)
+            idArr.push(searchResults.tracks.items[i].uri.replace('spotify:track:', ''))
+          return spotifyApi.getAudioFeaturesForTracks(idArr);
+        }).then(function(data){
+          results.features = data.body
+          res.json(results); 
+        })
+      .catch(function(err) {
+        console.error(err);
+      })
+  })
+
+  return router;
+}
+

--- a/server-sq/routes/search.js
+++ b/server-sq/routes/search.js
@@ -1,17 +1,16 @@
 const express = require("express");
 const router = express.Router()
 
-module.exports = function(spotifyApi, adminStatus) {
+module.exports = function(session) {
 
   router.post('/tracks', function(req, res){
-    console.log('Received search');
     const results = {
       tracks : {},
       features : {},
     }
     res.setHeader('Content-Type', 'application/json');
     console.log('Search Query', req.body.searchString);
-    spotifyApi.searchTracks(req.body.searchString,req.body.params).then(
+    session.spotify.searchTracks(req.body.searchString,req.body.params).then(
       function(data) {
         results.tracks = data.body;
         return data.body;
@@ -21,7 +20,7 @@ module.exports = function(spotifyApi, adminStatus) {
           //get id array from search
           for(let i = 0; i < searchResults.tracks.items.length; i++)
             idArr.push(searchResults.tracks.items[i].uri.replace('spotify:track:', ''))
-          return spotifyApi.getAudioFeaturesForTracks(idArr);
+          return session.spotify.getAudioFeaturesForTracks(idArr);
         }).then(function(data){
           results.features = data.body
           res.json(results); 

--- a/server-sq/server.js
+++ b/server-sq/server.js
@@ -35,12 +35,11 @@ app.use((req, res, next) => {
 const clientId = process.env.CLIENT_ID, clientSecret = process.env.CLIENT_SECRET;
 const spotifyApi = new SpotifyWebApi({clientId: clientId, clientSecret: clientSecret, redirectUri: process.env.SITE_URL + '/auth'});
 const session = new SessionManager();
-const hostStatus = { adminSet : false, activePlaying : false, accessToken : '', playbackState : {} };
 
 app.use('/host', host(session));
 app.use('/search', search(session));
 app.use('/queue', queue(io, session));
-//app.use('/playback', playback(io, spotifyApi, hostStatus));
+app.use('/playback', playback(io, session));
 
 // Open to port
 server.listen(process.env.PORT || 3001, () => {

--- a/server-sq/server.js
+++ b/server-sq/server.js
@@ -1,100 +1,56 @@
+// Modules
 const express = require("express");
-const SpotifyWebApi = require("spotify-web-api-node");
 const app = express();
+const server = require('http').createServer(app);
+const io = require('socket.io')(server, {cors: {origin: "*"}});
+const SpotifyWebApi = require("spotify-web-api-node");
+const cors = require('cors');
 const bodyParser = require('body-parser');
+
+// Route Files
+const host = require('./routes/host')
+const search = require('./routes/search')
 const queue = require('./routes/queue')
 const playback = require('./routes/playback')
-app.use(bodyParser.json())
 
 // Deployment Related Functionality
 if (process.env.NODE_ENV !== 'production') {
   require('dotenv').config();
 }
 
-app.use((req, res, next) => {
-  res.header("Access-Control-Allow-Origin", "*");
-  res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
-  next();
-});
+// Express Setup
+app.use(bodyParser.json())
+// CORS: Cross-Origin Resource Sharing
+app.use(cors())
+/*
+  app.use((req, res, next) => {
+    res.header("Access-Control-Allow-Origin", "*");
+    res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+    next();
+  });
+*/
+// Socket Setup
 
 // API
 const clientId = process.env.CLIENT_ID, clientSecret = process.env.CLIENT_SECRET;
 const spotifyApi = new SpotifyWebApi({clientId: clientId, clientSecret: clientSecret, redirectUri: process.env.SITE_URL + '/auth'});
-const adminStatus = { adminSet : false, activePlaying : false, accessToken : '', playbackState : {} };
+const hostStatus = { adminSet : false, activePlaying : false, accessToken : '', playbackState : {} };
 
-app.post('/searchTracks', function(req, res){
-  const results = {
-    tracks : {},
-    features : {},
-  }
-  res.setHeader('Content-Type', 'application/json');
-  console.log('Search Query', req.body.searchString);
-  spotifyApi.searchTracks(req.body.searchString,req.body.params).then(
-    function(data) {
-      results.tracks = data.body;
-      return data.body;
-    }).then(
-      function(searchResults){
-        const idArr = [];
-        //get id array from search
-        for(let i = 0; i < searchResults.tracks.items.length; i++)
-          idArr.push(searchResults.tracks.items[i].uri.replace('spotify:track:', ''))
-        return spotifyApi.getAudioFeaturesForTracks(idArr);
-      }).then(function(data){
-        results.features = data.body
-        res.json(results); 
-      })
-    .catch(function(err) {
-      console.error(err);
-    })
-})
-
-app.post('/adminLogin', (req,res) => {
-  const code = req.body.code
-  spotifyApi.authorizationCodeGrant(code).then(
-    function(data) {
-      adminStatus.accessToken = data.body['access_token']
-      // Set the access token on the API object to use it in later calls
-      spotifyApi.setAccessToken(data.body['access_token']);
-      spotifyApi.setRefreshToken(data.body['refresh_token']);
-      adminStatus.adminSet = true; //Flag verifying token set (Concept in case we need to add more adminstrative features from client)
-      console.log('Host set')
-    },
-    function(err) {
-      adminStatus.adminSet = false;
-      console.log('Error logging in host: ', err);
-    })
-    .catch(() => {
-      res.sendStatus(400);
-    })
-  res.send('Done')
-})
-
-// Can be useful
-app.get('/adminStatus', (req, res) => {
-  res.json(adminStatus);
-})
-
-app.get('/token', (req, res) => {
-  res.send(adminStatus.accessToken)
-})
-
-//refresh token every 30 minutes
-setInterval(() => {
-  spotifyApi.refreshAccessToken().then((data) => {
-    console.log('Access token refreshed')
-    adminStatus.accessToken = data.body['access_token']
-    spotifyApi.setAccessToken(data.body['access_token']);
-  }, (err) => {
-    console.log('Could not refresh access token', err);
-    adminStatus.adminSet = false;
-  }
-  )}, 1800000);
-
-app.use('/queue', queue(spotifyApi, adminStatus));
-app.use('/playback', playback(spotifyApi, adminStatus));
+app.use('/host', host(spotifyApi, hostStatus));
+app.use('/queue', queue(io, spotifyApi, hostStatus));
+app.use('/playback', playback(io, spotifyApi, hostStatus));
+app.use('/search', search(spotifyApi, hostStatus));
 
 // Open to port
-app.listen(process.env.PORT || 3001, () => {
+server.listen(process.env.PORT || 3001, () => {
   console.log('Beachmuse API Active');
 });
+
+// Socket Handlers
+io.on('connection', (socket) => {
+  socket.emit('id', socket.id);
+  console.log(socket.id + ' connected');
+  socket.on('disconnect', (reason) => {
+  })
+});
+

--- a/server-sq/server.js
+++ b/server-sq/server.js
@@ -39,7 +39,7 @@ const hostStatus = { adminSet : false, activePlaying : false, accessToken : '', 
 
 app.use('/host', host(session));
 app.use('/search', search(session));
-//app.use('/queue', queue(io, spotifyApi, hostStatus));
+app.use('/queue', queue(io, session));
 //app.use('/playback', playback(io, spotifyApi, hostStatus));
 
 // Open to port

--- a/server-sq/server.js
+++ b/server-sq/server.js
@@ -37,10 +37,10 @@ const spotifyApi = new SpotifyWebApi({clientId: clientId, clientSecret: clientSe
 const session = new SessionManager();
 const hostStatus = { adminSet : false, activePlaying : false, accessToken : '', playbackState : {} };
 
-app.use('/host', host(spotifyApi, hostStatus));
-app.use('/queue', queue(io, spotifyApi, hostStatus));
-app.use('/playback', playback(io, spotifyApi, hostStatus));
-app.use('/search', search(spotifyApi, hostStatus));
+app.use('/host', host(spotifyApi, session));
+//app.use('/search', search(spotifyApi, hostStatus));
+//app.use('/queue', queue(io, spotifyApi, hostStatus));
+//app.use('/playback', playback(io, spotifyApi, hostStatus));
 
 // Open to port
 server.listen(process.env.PORT || 3001, () => {

--- a/server-sq/server.js
+++ b/server-sq/server.js
@@ -22,13 +22,12 @@ if (process.env.NODE_ENV !== 'production') {
 app.use(bodyParser.json())
 // CORS: Cross-Origin Resource Sharing
 app.use(cors())
-/*
-  app.use((req, res, next) => {
-    res.header("Access-Control-Allow-Origin", "*");
-    res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
-    next();
-  });
-*/
+app.use((req, res, next) => {
+  res.header("Access-Control-Allow-Origin", "*");
+  res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+  next();
+});
+
 // Socket Setup
 
 // API

--- a/server-sq/server.js
+++ b/server-sq/server.js
@@ -37,8 +37,8 @@ const spotifyApi = new SpotifyWebApi({clientId: clientId, clientSecret: clientSe
 const session = new SessionManager();
 const hostStatus = { adminSet : false, activePlaying : false, accessToken : '', playbackState : {} };
 
-app.use('/host', host(spotifyApi, session));
-//app.use('/search', search(spotifyApi, hostStatus));
+app.use('/host', host(session));
+app.use('/search', search(session));
 //app.use('/queue', queue(io, spotifyApi, hostStatus));
 //app.use('/playback', playback(io, spotifyApi, hostStatus));
 

--- a/server-sq/server.js
+++ b/server-sq/server.js
@@ -29,11 +29,7 @@ app.use((req, res, next) => {
   next();
 });
 
-// Socket Setup
-
 // API
-const clientId = process.env.CLIENT_ID, clientSecret = process.env.CLIENT_SECRET;
-const spotifyApi = new SpotifyWebApi({clientId: clientId, clientSecret: clientSecret, redirectUri: process.env.SITE_URL + '/auth'});
 const session = new SessionManager();
 
 app.use('/host', host(session));

--- a/server-sq/server.js
+++ b/server-sq/server.js
@@ -6,6 +6,7 @@ const io = require('socket.io')(server, {cors: {origin: "*"}});
 const SpotifyWebApi = require("spotify-web-api-node");
 const cors = require('cors');
 const bodyParser = require('body-parser');
+const SessionManager = require('./models/SessionManager');
 
 // Route Files
 const host = require('./routes/host')
@@ -33,6 +34,7 @@ app.use((req, res, next) => {
 // API
 const clientId = process.env.CLIENT_ID, clientSecret = process.env.CLIENT_SECRET;
 const spotifyApi = new SpotifyWebApi({clientId: clientId, clientSecret: clientSecret, redirectUri: process.env.SITE_URL + '/auth'});
+const session = new SessionManager();
 const hostStatus = { adminSet : false, activePlaying : false, accessToken : '', playbackState : {} };
 
 app.use('/host', host(spotifyApi, hostStatus));


### PR DESCRIPTION
This PR includes commits modifying client and server code to an HTTP Socket model, removing client polling to our backend and reducing the amount of data being sent in some functions of the application. For example, when a new song is added to the queue, we no longer needed to have the client poll for the entire queue. A broadcast is emitted to all connected sockets with just the new song to be added rather than the entire queue. Other functions follow this approach, including but not limited to the playback state, history updates, etc. A REST model is still used for fetching information for searches as well as on initial page loads. 

This PR the feature for Jira story SQ-92, introducing the limit for recently played songs. 