### PR TITLE
Host change sync

### DIFF
--- a/server-sq/models/SessionManager.js
+++ b/server-sq/models/SessionManager.js
@@ -19,8 +19,16 @@ class SessionManager {
     return this._queue;
   }
 
+  set queue(newQueue){
+    this._queue = newQueue;
+  }
+
   get history(){
     return this._history;
+  }
+
+  set history(newHistory){
+    this._history = newHistory;
   }
 
   get status(){
@@ -98,8 +106,21 @@ class SessionManager {
     this._history.push(this._queue.shift());
   }
 
+  resetSession(){
+    this._queue = [];
+    this._history = [];
+    this._status = {
+      host : false,
+      active : false,
+      accessToken : '',
+    };
+    this._playback = {};
+    this._buffer = [];
+  }
+
   // Spotify
   authenticate(code){
+    this.resetSession();
     return this.spotifyApi.authorizationCodeGrant(code).then((data) => {
       this._status.accessToken = data.body['access_token']
       // Set the access token on the API object to use it in later calls

--- a/server-sq/models/SessionManager.js
+++ b/server-sq/models/SessionManager.js
@@ -120,13 +120,14 @@ class SessionManager {
 
   // Spotify
   authenticate(code){
-    this.resetSession();
+    this._buffer = [];
     return this.spotifyApi.authorizationCodeGrant(code).then((data) => {
       this._status.accessToken = data.body['access_token']
       // Set the access token on the API object to use it in later calls
       this.spotifyApi.setAccessToken(data.body['access_token']);
       this.spotifyApi.setRefreshToken(data.body['refresh_token']);
       this.status.host = true; //Flag verifying token set (Concept in case we need to add more adminstrative features from client)
+      this._buffer = this._queue.map(item => item.uri); 
       console.log('Host set')
       return(200);
     }, (err) => {


### PR DESCRIPTION
This PR adds an API design where when a new host logs in, all songs currently in the queue are pushed to the new hosts Spotify. This ensures that songs that are in queue are guaranteed to be played. 

However, suppose that the new host has songs already in their Spotify queue, these songs will be added regardless of whether they will be played more than once.