### PR TITLE
feat(queue): Limit to 1-minute downtime for unique user queueing

### DIFF
--- a/server-sq/routes/queue.js
+++ b/server-sq/routes/queue.js
@@ -22,10 +22,10 @@ module.exports = function(socket, session) {
     }
     if (added) {
       socket.emit('queueAdd', req.body);
-      res.send("Added to queue");
+      res.send('PASS');
     }
     else {
-      res.send("Failed to add song to queue");
+      res.send('FAIL');
     }
   })
 


### PR DESCRIPTION
A localStorage variable is used to record the times when a user submits a song successfully to the queue. This is a basic method without having to require our backend to track all connected users. There are exploits to this, such as when a client does not save localStorage variables between browser sessions.

A secure version would be IP caching in our backend. The data is in my opinion not sensitive enough so that we should consider it.

Changes to the administrative page are on the way.